### PR TITLE
fix: check for the `file` utility

### DIFF
--- a/Blocklist-builder.sh
+++ b/Blocklist-builder.sh
@@ -149,6 +149,7 @@ check_dependencies() {
 
     local missing_deps=()
 
+    command -v file &>/dev/null || missing_deps+=("file")
     command -v curl &>/dev/null || missing_deps+=("curl")
     command -v gunzip &>/dev/null || missing_deps+=("gzip")
     command -v awk &>/dev/null || missing_deps+=("awk")


### PR DESCRIPTION
It seems like a basic tool on most of Linux systems, but for instance, on a Rapsbian it was missing by default.

I guess it is harmful to check for it.